### PR TITLE
[BREAKING CHANGE] Lexicographic Alphabet

### DIFF
--- a/Token.go
+++ b/Token.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// Base62 is a string respresentation of every possible base62 character
-	Base62 = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	Base62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 	// MaxTokenLength is the largest possible character length of a token
 	MaxTokenLength = 10


### PR DESCRIPTION
Changed the alphabet so tokens are lexicographically sortable. This will ensure that two tokens of the same length will follow the same sorting behaviour as the integers they are generated from. If they not of the same length left-zero-padding the shorter token will provide a lexicographic sort. 

This will break all deployments because the decoding will no longer result in the same integer. Feel free to either make a new major version of the library or reject this change.